### PR TITLE
Add integer overflow detection to mep_calloc().

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -114,6 +114,8 @@ down:
 void *mep_calloc(mep_t *mp, size_t count, size_t size)
 {
     void *ptr;
+    if (size > (size_t)-1 / count)
+        return NULL; /* overflow */
     if ( NULL == (ptr = mep_alloc(mp, size * count)) )
         return NULL;
     memset(ptr, 0, size * count); /* todo we need memset depend on memory alignment to gunrentee speed */

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -77,4 +77,9 @@ void test_main (TEST_POOL_T *mp)
     TEST_ASSERT(stats.total == TEST_LINE_SIZE);
     TEST_SUCS("[PASSED]");
 #   endif
+
+    TEST_PRINT("Overflow detection");
+    ptr = TEST_CALLOC(mp, -1, -1);
+    TEST_ASSERT(ptr == NULL);
+    TEST_SUCS("[PASSED]");
 }


### PR DESCRIPTION
Passing two large numbers to mep_calloc() may return an allocation
smaller than requested and expected. This change causes mep_calloc() to
return NULL if the requested size cannot be represented in a size_t.